### PR TITLE
Add support for anonymizeIP setting

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "Google Analytics",
-	"version": "1.0",
+	"version": "1.1",
 	"description": "Automatically add Google Analytics code to any theme.",
 	"demo": "http://koken.me",
 	"author": {
@@ -18,6 +18,11 @@
 				"rule":	"^UA\\-[0-9]{4,10}\\-\\d{1,2}$",
 				"error_message": "Not a valid tracking ID. It should be in this format: UA-XXXXXXXX-X"
 			}
+		},
+		"anonymize": {
+			"label": "Anonymize IP",
+			"info": "Tells Google Analytics to anonymize the information sent by the tracker objects by removing the last octet of the IP address prior to its storage. Note that this will slightly reduce the accuracy of geographic reporting.",
+			"type": "boolean"
 		}
 	}
 }

--- a/plugin.php
+++ b/plugin.php
@@ -10,6 +10,7 @@ class KokenGoogleAnalytics extends KokenPlugin {
 
 	function render()
 	{
+		$anonymize = $this->data->anonymize ? 'true' : 'false';
 
 		echo <<<OUT
 <script type="text/javascript">
@@ -17,6 +18,7 @@ class KokenGoogleAnalytics extends KokenPlugin {
 	var _gaq = _gaq || [];
 	_gaq.push(['_setAccount', '{$this->data->tracking_id}']);
  	_gaq.push(['_trackPageview']);
+ 	_gaq.push(['_anonymizeIP', {$anonymize}]);
 
  	(function() {
 		var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;


### PR DESCRIPTION
The current version of the Google Analytics Plugin does not support the "anonymizeIP" setting, which hides the last octet of the user's IP address. This however is important for some people, as e.g. in Germany you must use anonymized IP addresses for statistics.
